### PR TITLE
Fixed a link

### DIFF
--- a/team.md
+++ b/team.md
@@ -1,4 +1,4 @@
 1. [Josh Bongard](https://www.meclab.org/) (University of Vermont)
-2. [Melanie Moses](moseslab.cs.unm.edu) (University of New Mexico)
+2. [Melanie Moses](https://moseslab.cs.unm.edu/) (University of New Mexico)
 3. [Nicholas Cheney](http://www.uvm.edu/neurobotics) (University of Vermont)
 4. [Michael Levin](https://ase.tufts.edu/biology/labs/levin/) (Tufts/Harvard University)


### PR DESCRIPTION
https:// was missing, resulting in a 404 at https://proteusinstitute.github.io/team